### PR TITLE
Implement SSE notification listening

### DIFF
--- a/fractalrhomb.py
+++ b/fractalrhomb.py
@@ -44,7 +44,7 @@ log_formatter = logging.Formatter(
 log_handler.setFormatter(log_formatter)
 root_logger.addHandler(log_handler)
 
-PING_LATENCY_HIGH = 10.0
+PING_LATENCY_HIGH = 9
 
 
 @bot.event

--- a/fractalrhomb.py
+++ b/fractalrhomb.py
@@ -482,10 +482,11 @@ async def restart_notification_listener(ctx: discord.ApplicationContext) -> None
 	# TODO: I don't want to add 100 lists of users for every little operation
 	# that might be privileged, so I'm just gonna reuse this one.
 	# Maybe we could just have one ADMIN_USERS list.
-	privileged_users = json.loads(getenv("FORCE_PURGE_ALLOWED"), "[]")
+	privileged_users = json.loads(getenv("FORCE_PURGE_ALLOWED", "[]"))
 
-	if ctx.author.id not in privileged_users:
-		discord_logger.warning(f"Unauthorized notif listener restart attempt by {ctx.author.id}.")
+    user_id = str(ctx.author.id)
+	if user_id not in privileged_users:
+		discord_logger.warning(f"Unauthorized notif listener restart attempt by {user_id}.")
 		await ctx.respond("you cannot do that.")
 		return
 

--- a/fractalrhomb.py
+++ b/fractalrhomb.py
@@ -484,7 +484,7 @@ async def restart_notification_listener(ctx: discord.ApplicationContext) -> None
 	# Maybe we could just have one ADMIN_USERS list.
 	privileged_users = json.loads(getenv("FORCE_PURGE_ALLOWED", "[]"))
 
-    user_id = str(ctx.author.id)
+	user_id = str(ctx.author.id)
 	if user_id not in privileged_users:
 		discord_logger.warning(f"Unauthorized notif listener restart attempt by {user_id}.")
 		await ctx.respond("you cannot do that.")

--- a/fractalrhomb.py
+++ b/fractalrhomb.py
@@ -44,7 +44,7 @@ log_formatter = logging.Formatter(
 log_handler.setFormatter(log_formatter)
 root_logger.addHandler(log_handler)
 
-PING_LATENCY_HIGH = 9
+PING_LATENCY_HIGH = 10.0
 
 
 @bot.event

--- a/fractalrhomb.py
+++ b/fractalrhomb.py
@@ -27,6 +27,7 @@ import src.fractalrhomb_globals as frg
 from src.fractalrhomb_globals import bot
 from src.fractalthorns_api import FractalthornsAPI, fractalthorns_api
 from src.fractalthorns_exceptions import CachePurgeError
+import src.fractalthorns_notifications as ft_notifs
 
 load_dotenv()
 
@@ -571,7 +572,11 @@ async def main() -> None:
 
 		token = getenv("DISCORD_BOT_TOKEN")
 		async with bot:
-			await bot.start(token)
+			bot_task = asyncio.create_task(bot.start(token))
+			notifs_listen_task = asyncio.create_task(ft_notifs.listen_for_notifications())
+
+			await bot_task
+			await notifs_listen_task
 
 
 if __name__ == "__main__":

--- a/fractalrhomb.py
+++ b/fractalrhomb.py
@@ -481,8 +481,8 @@ async def test_command(ctx: discord.ApplicationContext) -> None:
 async def restart_notification_listener(ctx: discord.ApplicationContext) -> None:
 	# TODO: I don't want to add 100 lists of users for every little operation
 	# that might be privileged, so I'm just gonna reuse this one.
-	# Maybe we could just have one ADMIN_USERS list. PS
-	privileged_users = json.loads(getenv("FORCE_PURGE_ALLOWED"))
+	# Maybe we could just have one ADMIN_USERS list.
+	privileged_users = json.loads(getenv("FORCE_PURGE_ALLOWED"), "[]")
 
 	if ctx.author.id not in privileged_users:
 		discord_logger.warning(f"Unauthorized notif listener restart attempt by {ctx.author.id}.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiofiles==24.1.0
 aiohappyeyeballs==2.3.6
 aiohttp==3.10.3
+aiohttp-sse-client2=0.3.0
 aiosignal==1.3.1
 attrs==24.2.0
 frozenlist==1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiofiles==24.1.0
 aiohappyeyeballs==2.3.6
 aiohttp==3.10.3
-aiohttp-sse-client2=0.3.0
+aiohttp-sse-client2==0.3.0
 aiosignal==1.3.1
 attrs==24.2.0
 frozenlist==1.4.1

--- a/src/fractalrhomb_globals.py
+++ b/src/fractalrhomb_globals.py
@@ -53,7 +53,7 @@ class BotData:
 	"""Data class containing bot data/config."""
 
 	bot_channels: dict[str, list[str]]
-	news_post_channels: dict[str, list[str]]
+	news_post_channels: list[str]
 	purge_cooldowns: dict[str, dict[str, float]]
 	gather_cooldowns: dict[str, float]
 

--- a/src/fractalrhomb_globals.py
+++ b/src/fractalrhomb_globals.py
@@ -93,7 +93,7 @@ class BotData:
 			discord_logger.info("Saved bot data.")
 
 
-bot_data = BotData({}, {}, {}, {})
+bot_data = BotData({}, [], {}, {})
 
 USER_PURGE_COOLDOWN = dt.timedelta(hours=12)
 FULL_GATHER_COOLDOWN = dt.timedelta(hours=72)

--- a/src/fractalrhomb_globals.py
+++ b/src/fractalrhomb_globals.py
@@ -53,6 +53,7 @@ class BotData:
 	"""Data class containing bot data/config."""
 
 	bot_channels: dict[str, list[str]]
+	news_post_channels: dict[str, list[str]]
 	purge_cooldowns: dict[str, dict[str, float]]
 	gather_cooldowns: dict[str, float]
 
@@ -69,6 +70,9 @@ class BotData:
 			if data.get("bot_channels") is not None:
 				discord_logger.info("Loaded saved bot channels.")
 				self.bot_channels = data["bot_channels"]
+			if data.get("news_post_channels") is not None:
+				discord_logger.info("Loaded saved news post channels.")
+				self.news_post_channels = data["news_post_channels"]
 			if data.get("purge_cooldowns") is not None:
 				discord_logger.info("Loaded saved purge cooldowns.")
 				self.purge_cooldowns = data["purge_cooldowns"]
@@ -89,7 +93,7 @@ class BotData:
 			discord_logger.info("Saved bot data.")
 
 
-bot_data = BotData({}, {}, {})
+bot_data = BotData({}, {}, {}, {})
 
 USER_PURGE_COOLDOWN = dt.timedelta(hours=12)
 FULL_GATHER_COOLDOWN = dt.timedelta(hours=72)

--- a/src/fractalthorns_notifications.py
+++ b/src/fractalthorns_notifications.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2024 McAwesome (https://github.com/McAwesome123)
+# This script is licensed under the GNU Affero General Public License version 3 or later.
+# For more information, view the LICENSE file provided with this project
+# or visit: https://www.gnu.org/licenses/agpl-3.0.en.html
+
+# fractalthorns is a website created by Pierce Smith (https://github.com/pierce-smith1).
+# View it here: https://fractalthorns.com
+
+"""Code responsible for listening to and relaying SSE notifications."""
+
+import json
+import logging
+import re
+from os import getenv
+
+from aiohttp_sse_client2 import client as sse_client
+
+from src.fractalrhomb_globals import bot
+
+notifs_logger = logging.getLogger("notifs")
+
+async def listen_for_notifications() -> None:
+    async with sse_client.EventSource('http://localhost:4321/notifications') as event_source:
+        async for event in event_source:
+            await handle_notification(event)
+
+async def handle_notification(notification):
+    notifs_logger.info(f'caught a sse notification: {notification}')
+    body = notification.data
+
+    if '/' not in body:
+        notifs_logger.info(f'sse notification was malformed')
+        return
+
+    notification_type, payload = body.split('/', maxsplit=1)
+    notifs_logger.info(f'type: {notification_type}')
+
+    match notification_type:
+        case 'news_update':
+            await post_news_update(json.loads(payload))
+        case _:
+            notifs_logger.info(f'sse notification had an unknown type')
+            pass
+
+async def post_news_update(news_item):
+    news_channels = json.loads(getenv("NEWS_UPDATE_POST_CHANNELS", "[]"))
+
+    if len(news_channels) == 0:
+        notifs_logger.warning(f'wanted to post a notification, but no update channels are configured!')
+
+    for channel in news_channels:
+        discord_channel = bot.get_channel(int(channel))
+        await discord_channel.send(make_news_update_string(news_item))
+
+def make_news_update_string(news_item):
+    print(news_item)
+
+    # This is 100% going to cause a problem later, but YOLO
+    strip_html_tags = lambda s: re.sub('<[^<]+?>', '', s)
+
+    string = (
+        f'**fractalthorns update for** {news_item['date']}\n'
+        f'## {news_item['title']}\n'
+        f'{"* " + "\n* ".join(map(strip_html_tags, news_item['items']))}'
+    )
+
+    return string

--- a/src/fractalthorns_notifications.py
+++ b/src/fractalthorns_notifications.py
@@ -52,25 +52,37 @@ async def listen_for_notifications() -> None:
     while True:
         notifs_logger.info(f'trying to connect to sse endpoint')
         try:
-            async with sse_client.EventSource('http://localhost:4321/notifications-test') as event_source:
+            async with sse_client.EventSource('http://localhost:4321/notifications-test', timeout=None) as event_source:
+                # Yes, you are reading that correctly. I just passed timeout=None to a SSE client.
+                # Guess what happens if you don't? The request times out after 5 minutes, as is the aiohttp default.
+                #
+                # https://github.com/rtfol/aiohttp-sse-client/issues/161
+                # WHAT
+                #      THE
+                #           FUCK
+                #
+                # How does something like this even happen??? HOW IS IT STILL NOT FIXED???
+                # Oh no, it's cool, my other car is a graphics library that can only draw one triangle at a time.
                 async for event in event_source:
                     await handle_notification(event)
                     retry_interval = BASE_RETRY_INTERVAL
 
         except (aiohttp.ClientPayloadError, ConnectionError) as ex:
-            # This SSE client does have its own retry logic, but it will only 
-            # retry on certain very specific failures.
-            # These two exception types cover the most common reasons the connection
-            # might fail - those being 1) the server is entirely down or
-            # 2) it is broken and spitting 400s or 500s - which are NOT
-            # automatically retried by the client and have to be picked up
-            # by us.
+            # This SSE client does have its own retry logic, but it will only retry on certain very specific failures.
+            # These two exception types cover the most common reasons the connection might fail - those being 
+            # 1) the server is entirely down, or 
+            # 2) it is broken and spitting 400s or 500s...
+            # neither of which are  automatically retried by the client and have to be picked up by us.
             notifs_logger.warning(f'lost connection to sse server because of {type(ex)} "{ex}", trying again in {retry_interval.total_seconds()} seconds')
 
             await asyncio.sleep(retry_interval.total_seconds())
 
             retry_interval *= 2
             retry_interval = MAX_RETRY_INTERVAL if retry_interval > MAX_RETRY_INTERVAL else retry_interval
+
+        except TimeoutError:
+            # Just in case aiohttp is still unhappy with leaving a single HTTP request open for a week.
+            notifs_logger.warning(f'sse client timed out, reconnecting...')
         
 async def handle_notification(notification):
     notifs_logger.info(f'caught a sse notification: {notification}')

--- a/src/fractalthorns_notifications.py
+++ b/src/fractalthorns_notifications.py
@@ -35,8 +35,7 @@ async def start_and_watch_notification_listener() -> None:
 
         if listener_task.cancelled():
             notifs_logger.warning(f'sse listener was cancelled.')
-
-        if (listener_exception := listener_task.exception()) is not None:
+        elif (listener_exception := listener_task.exception()) is not None:
             notifs_logger.warning(f'sse listener failed with {type(listener_exception)} "{listener_exception}", the client will need to be manually restarted')
 
         notifs_logger.info(f'sse listener stopped. waiting to be manually resumed')

--- a/src/fractalthorns_notifications.py
+++ b/src/fractalthorns_notifications.py
@@ -29,88 +29,88 @@ MAX_RETRY_INTERVAL = timedelta(hours=1)
 resume_event = asyncio.Event()
 
 async def start_and_watch_notification_listener() -> None:
-    while True:
-        listener_task = asyncio.create_task(listen_for_notifications())
-        await asyncio.wait([listener_task], return_when=asyncio.FIRST_EXCEPTION)
+	while True:
+		listener_task = asyncio.create_task(listen_for_notifications())
+		await asyncio.wait([listener_task], return_when=asyncio.FIRST_EXCEPTION)
 
-        if listener_task.cancelled():
-            notifs_logger.warning(f'sse listener was cancelled.')
-        elif (listener_exception := listener_task.exception()) is not None:
-            notifs_logger.warning(f'sse listener failed with {type(listener_exception)} "{listener_exception}", the client will need to be manually restarted')
+		if listener_task.cancelled():
+			notifs_logger.warning(f'sse listener was cancelled.')
+		elif (listener_exception := listener_task.exception()) is not None:
+			notifs_logger.warning(f'sse listener failed with {type(listener_exception)} "{listener_exception}", the client will need to be manually restarted')
 
-        notifs_logger.info(f'sse listener stopped. waiting to be manually resumed')
-        await resume_event.wait()
+		notifs_logger.info(f'sse listener stopped. waiting to be manually resumed')
+		await resume_event.wait()
 
-        notifs_logger.info(f'sse listener is resuming')
-        resume_event.clear()
-        
+		notifs_logger.info(f'sse listener is resuming')
+		resume_event.clear()
+		
 
 async def listen_for_notifications() -> None:
-    retry_interval = BASE_RETRY_INTERVAL
+	retry_interval = BASE_RETRY_INTERVAL
 
-    while True:
-        notifs_logger.info(f'trying to connect to sse endpoint')
-        try:
-            # change this path to /notifications-test to get test messages
-            async with sse_client.EventSource('https://fractalthorns.com/notifications', timeout=None) as event_source:
-                # Yes, you are reading that correctly. I just passed timeout=None to a SSE client.
-                # Guess what happens if you don't? The request times out after 5 minutes, as is the aiohttp default.
-                #
-                # https://github.com/rtfol/aiohttp-sse-client/issues/161
-                # WHAT
-                #      THE
-                #           FUCK
-                #
-                # How does something like this even happen??? HOW IS IT STILL NOT FIXED???
-                # Oh no, it's cool, my other car is a graphics library that can only draw one triangle at a time.
-                async for event in event_source:
-                    await handle_notification(event)
-                    retry_interval = BASE_RETRY_INTERVAL
+	while True:
+		notifs_logger.info(f'trying to connect to sse endpoint')
+		try:
+			# change this path to /notifications-test to get test messages
+			async with sse_client.EventSource('https://fractalthorns.com/notifications', timeout=None) as event_source:
+				# Yes, you are reading that correctly. I just passed timeout=None to a SSE client.
+				# Guess what happens if you don't? The request times out after 5 minutes, as is the aiohttp default.
+				#
+				# https://github.com/rtfol/aiohttp-sse-client/issues/161
+				# WHAT
+				#      THE
+				#           FUCK
+				#
+				# How does something like this even happen??? HOW IS IT STILL NOT FIXED???
+				# Oh no, it's cool, my other car is a graphics library that can only draw one triangle at a time.
+				async for event in event_source:
+					await handle_notification(event)
+					retry_interval = BASE_RETRY_INTERVAL
 
-        except (aiohttp.ClientPayloadError, ConnectionError) as ex:
-            # This SSE client does have its own retry logic, but it will only retry on certain very specific failures.
-            # These two exception types cover the most common reasons the connection might fail, those being:
-            # 1) the server is entirely down, or 
-            # 2) the backend is down and spitting 400s or 500s
-            # Neither of these are automatically retried by the client and have to be picked up by us.
-            notifs_logger.warning(f'lost connection to sse server because of {type(ex)} "{ex}", trying again in {retry_interval.total_seconds()} seconds')
+		except (aiohttp.ClientPayloadError, ConnectionError) as ex:
+			# This SSE client does have its own retry logic, but it will only retry on certain very specific failures.
+			# These two exception types cover the most common reasons the connection might fail, those being:
+			# 1) the server is entirely down, or 
+			# 2) the backend is down and spitting 400s or 500s
+			# Neither of these are automatically retried by the client and have to be picked up by us.
+			notifs_logger.warning(f'lost connection to sse server because of {type(ex)} "{ex}", trying again in {retry_interval.total_seconds()} seconds')
 
-            await asyncio.sleep(retry_interval.total_seconds())
+			await asyncio.sleep(retry_interval.total_seconds())
 
-            retry_interval *= 2
-            retry_interval = MAX_RETRY_INTERVAL if retry_interval > MAX_RETRY_INTERVAL else retry_interval
+			retry_interval *= 2
+			retry_interval = MAX_RETRY_INTERVAL if retry_interval > MAX_RETRY_INTERVAL else retry_interval
 
-        except TimeoutError:
-            # Even though I asked it for no timeout, aiohttp may still be unhappy with 
-            # leaving a single GET request open for a week. So just in case...
-            notifs_logger.warning(f'sse client timed out, reconnecting...')
-        
+		except TimeoutError:
+			# Even though I asked it for no timeout, aiohttp may still be unhappy with 
+			# leaving a single GET request open for a week. So just in case...
+			notifs_logger.warning(f'sse client timed out, reconnecting...')
+		
 async def handle_notification(notification):
-    notifs_logger.info(f'caught a sse notification: {notification}')
-    body = notification.data
+	notifs_logger.info(f'caught a sse notification: {notification}')
+	body = notification.data
 
-    if '/' not in body:
-        notifs_logger.info(f'sse notification is missing a type delimiter! ignoring')
-        return
+	if '/' not in body:
+		notifs_logger.info(f'sse notification is missing a type delimiter! ignoring')
+		return
 
-    notification_type, payload = body.split('/', maxsplit=1)
-    notifs_logger.info(f'type: {notification_type}')
+	notification_type, payload = body.split('/', maxsplit=1)
+	notifs_logger.info(f'type: {notification_type}')
 
-    match notification_type:
-        case 'news_update':
-            news_item = ftd.NewsEntry.from_obj(json.loads(payload))
-            await post_news_update(news_item)
-        case _:
-            notifs_logger.info(f'sse notification had an unknown type: {notification_type}')
+	match notification_type:
+		case 'news_update':
+			news_item = ftd.NewsEntry.from_obj(json.loads(payload))
+			await post_news_update(news_item)
+		case _:
+			notifs_logger.info(f'sse notification had an unknown type: {notification_type}')
 
 async def post_news_update(news_item):
-    news_channels = bot_data.news_post_channels
+	news_channels = bot_data.news_post_channels
 
-    if len(news_channels) == 0:
-        notifs_logger.warning(f'wanted to post a notification, but no update channels are configured!')
+	if len(news_channels) == 0:
+		notifs_logger.warning(f'wanted to post a notification, but no update channels are configured!')
 
-    for channel in news_channels:
-        notifs_logger.info(f'posting a news update')
+	for channel in news_channels:
+		notifs_logger.info(f'posting a news update')
 
-        discord_channel = bot.get_channel(int(channel))
-        await discord_channel.send(news_item.format())
+		discord_channel = bot.get_channel(int(channel))
+		await discord_channel.send(news_item.format())

--- a/src/fractalthorns_notifications.py
+++ b/src/fractalthorns_notifications.py
@@ -64,7 +64,6 @@ async def handle_notification(notification):
             await post_news_update(json.loads(payload))
         case _:
             notifs_logger.info(f'sse notification had an unknown type: {notification_type}')
-            pass
 
 async def post_news_update(news_item):
     news_channels = json.loads(getenv("NEWS_UPDATE_POST_CHANNELS", "[]"))

--- a/src/fractalthorns_notifications.py
+++ b/src/fractalthorns_notifications.py
@@ -21,7 +21,7 @@ from aiohttp_sse_client2 import client as sse_client
 from src.fractalrhomb_globals import bot
 import src.fractalthorns_dataclasses as ftd
 
-notifs_logger = logging.getLogger("discord")
+notifs_logger = logging.getLogger("notifs")
 
 BASE_RETRY_INTERVAL = timedelta(seconds=30)
 MAX_RETRY_INTERVAL = timedelta(hours=1)

--- a/src/fractalthorns_notifications.py
+++ b/src/fractalthorns_notifications.py
@@ -18,7 +18,7 @@ from datetime import timedelta
 
 from aiohttp_sse_client2 import client as sse_client
 
-from src.fractalrhomb_globals import bot
+from src.fractalrhomb_globals import bot, bot_data
 import src.fractalthorns_dataclasses as ftd
 
 notifs_logger = logging.getLogger("notifs")
@@ -104,7 +104,7 @@ async def handle_notification(notification):
             notifs_logger.info(f'sse notification had an unknown type: {notification_type}')
 
 async def post_news_update(news_item):
-    news_channels = json.loads(getenv("NEWS_UPDATE_POST_CHANNELS", "[]"))
+    news_channels = bot_data.news_post_channels
 
     if len(news_channels) == 0:
         notifs_logger.warning(f'wanted to post a notification, but no update channels are configured!')

--- a/src/fractalthorns_notifications.py
+++ b/src/fractalthorns_notifications.py
@@ -8,25 +8,46 @@
 
 """Code responsible for listening to and relaying SSE notifications."""
 
+import asyncio
 import json
 import logging
 import re
 from os import getenv
+from datetime import timedelta
 
 from aiohttp_sse_client2 import client as sse_client
 
 from src.fractalrhomb_globals import bot
 
-notifs_logger = logging.getLogger("notifs")
+notifs_logger = logging.getLogger("discord")
+
+BASE_RETRY_INTERVAL = timedelta(seconds=30)
+MAX_RETRY_INTERVAL = timedelta(hours=1)
 
 async def listen_for_notifications() -> None:
-    async with sse_client.EventSource('https://fractalthorns.com/notifications') as event_source:
-        try:
-            async for event in event_source:
-                await handle_notification(event)
-        except ConnectionError:
-            pass
+    retry_interval = BASE_RETRY_INTERVAL
 
+    while True:
+        notifs_logger.info(f'trying to connect to sse endpoint')
+        try:
+            async with sse_client.EventSource('https://fractalthorns.com/notifications') as event_source:
+                async for event in event_source:
+                    await handle_notification(event)
+                    retry_interval = BASE_RETRY_INTERVAL
+
+        except Exception:
+            # This SSE client does have its own retry logic, but it will only 
+            # retry on certain very specific failures.
+            # If the server 503s, for example, it will permanently give up.
+            # If it can't get a connection for any reason, I still want the bot 
+            # to continually retry no matter what so that it doesn't have to be
+            # restarted, so we need a little bit of custom retry logic.
+            notifs_logger.warning(f'couldn\'t connect to the sse server, trying again in {retry_interval.total_seconds()} seconds')
+            await asyncio.sleep(retry_interval.total_seconds())
+
+            retry_interval *= 2
+            retry_interval = MAX_RETRY_INTERVAL if retry_interval > MAX_RETRY_INTERVAL else retry_interval
+        
 async def handle_notification(notification):
     notifs_logger.info(f'caught a sse notification: {notification}')
     body = notification.data

--- a/src/fractalthorns_notifications.py
+++ b/src/fractalthorns_notifications.py
@@ -52,7 +52,8 @@ async def listen_for_notifications() -> None:
     while True:
         notifs_logger.info(f'trying to connect to sse endpoint')
         try:
-            async with sse_client.EventSource('http://localhost:4321/notifications-test', timeout=None) as event_source:
+            # change this path to /notifications-test to get test messages
+            async with sse_client.EventSource('https://fractalthorns.com/notifications', timeout=None) as event_source:
                 # Yes, you are reading that correctly. I just passed timeout=None to a SSE client.
                 # Guess what happens if you don't? The request times out after 5 minutes, as is the aiohttp default.
                 #
@@ -69,10 +70,10 @@ async def listen_for_notifications() -> None:
 
         except (aiohttp.ClientPayloadError, ConnectionError) as ex:
             # This SSE client does have its own retry logic, but it will only retry on certain very specific failures.
-            # These two exception types cover the most common reasons the connection might fail - those being 
+            # These two exception types cover the most common reasons the connection might fail, those being:
             # 1) the server is entirely down, or 
-            # 2) it is broken and spitting 400s or 500s...
-            # neither of which are  automatically retried by the client and have to be picked up by us.
+            # 2) the backend is down and spitting 400s or 500s
+            # Neither of these are automatically retried by the client and have to be picked up by us.
             notifs_logger.warning(f'lost connection to sse server because of {type(ex)} "{ex}", trying again in {retry_interval.total_seconds()} seconds')
 
             await asyncio.sleep(retry_interval.total_seconds())
@@ -81,7 +82,8 @@ async def listen_for_notifications() -> None:
             retry_interval = MAX_RETRY_INTERVAL if retry_interval > MAX_RETRY_INTERVAL else retry_interval
 
         except TimeoutError:
-            # Just in case aiohttp is still unhappy with leaving a single HTTP request open for a week.
+            # Even though I asked it for no timeout, aiohttp may still be unhappy with 
+            # leaving a single GET request open for a week. So just in case...
             notifs_logger.warning(f'sse client timed out, reconnecting...')
         
 async def handle_notification(notification):


### PR DESCRIPTION
fractalthorns.com has a new `/notifications` endpoint, which acts as an [SSE server](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) to notify interested clients of events on the site. This PR adds support for connecting to this SSE server, staying connected in the face of server failures, and handling the incoming `news_update` notifications (currently the only type of notification).

The new client is implemented as an asyncio task that runs alongside the main bot task. Failures in the client should stay entirely isolated and not take down the bot itself. A privileged slash command, `/restart-notification-listener`, is provided to manually restart the client without needing to restart the entire bot if it goes down for some transient reason.

For the handling of `news_update` notifications, all we do is post the formatted news item to all the channels listed in the `NEWS_UPDATE_POST_CHANNELS` environment variable.

## Verification

For testing, you can replace the url `https://fractalthorns.com/notifications` with `https://fractalthorns.com/notifications-test`, which is a special SSE endpoint that will send dummy messages every 10 seconds. Obviously, if you connect to the normal `/notifications` endpoint, you won't see any messages for a long time.