### PR TITLE
Fixes for notifications client

### DIFF
--- a/fractalrhomb.py
+++ b/fractalrhomb.py
@@ -592,9 +592,19 @@ async def restart_notification_listener(ctx: discord.ApplicationContext) -> None
 		return
 
 	ft_notifs.resume_event.set()
-	response = "listener has been restarted."
-	await frg.send_message(ctx, response)
+	ft_notifs.resume_done_event.clear()
 
+	try:
+		await ctx.defer()
+		await asyncio.wait_for(ft_notifs.resume_done_event.wait(), timeout=5.0)
+	except TimeoutError:
+		response = "listener didn't restart - it either didn't need restarting or is slow/dead."
+		await frg.send_message(ctx, response, is_deferred=True)
+	else:
+		response = "listener has been restarted."
+		await frg.send_message(ctx, response, is_deferred=True)
+
+	ft_notifs.resume_event.clear()
 
 def parse_arguments() -> None:
 	"""Parse command line arguments."""

--- a/src/fractalthorns_notifications.py
+++ b/src/fractalthorns_notifications.py
@@ -87,7 +87,11 @@ async def listen_for_notifications() -> None:
 				retry_interval.total_seconds(),
 			)
 
-			await asyncio.sleep(retry_interval.total_seconds())
+			sleep_until_retry_timeout = asyncio.create_task(asyncio.sleep(retry_interval.total_seconds()))
+			wait_for_manual_restart = asyncio.create_task(resume_event.wait())
+			await asyncio.wait([sleep_until_retry_timeout, wait_for_manual_restart], return_when=asyncio.FIRST_COMPLETED)
+
+			resume_event.clear()
 
 			retry_interval *= 2
 			retry_interval = min(retry_interval, MAX_RETRY_INTERVAL)

--- a/src/fractalthorns_notifications.py
+++ b/src/fractalthorns_notifications.py
@@ -70,9 +70,9 @@ async def listen_for_notifications() -> None:
 				#
 				# How does something like this even happen??? HOW IS IT STILL NOT FIXED???
 				# Oh no, it's cool, my other car is a graphics library that can only draw one triangle at a time.
+				retry_interval = BASE_RETRY_INTERVAL
 				async for event in event_source:
 					await handle_notification(event)
-					retry_interval = BASE_RETRY_INTERVAL
 
 		except (aiohttp.ClientPayloadError, ConnectionError) as ex:
 			# This SSE client does have its own retry logic, but it will only retry on certain very specific failures.


### PR DESCRIPTION
There are some issues with the notifications handler that is making notifications slow and annoying:

* There's a bug where the retry timeout grows on each server disconnect but never gets reset unless a notification is fully handled. This makes the bot wait for way too long if there are long periods where there are lots of server restarts and no notifications (which is the common situation). 
* There is no manual way to bypass this refresh timeout. `/restart-notifications-listener` can only resume the listener when it completely dies due to an unexpected exception. It would be nice if it could also force an immediate retry even if we're waiting for a retry timeout.

This PR tries to address both of those things. I didn't test this very much because trying to run this locally is being an absolute bitch for some reason, but these are very small changes and I ran through the basic cases so I'm at least 70% sure it's good.