### PR TITLE
More logger customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Some scripts for starting the bot (don't worry, you can still make your own)
   - Any command line arguments given to the provided script will be passed to the bot
+  - Note for making your own script: the logging library will create log files in the **current working directory** (which may not be the same as where the script is located)
+- PowerShell scripts since not everyone uses command prompt anymore
 - Customization for the file logger via .env
   - `LOG_FILE_NAME` for the file name to be used (default: "discord.log")
   - `LOG_FILE_WHEN` for the type of interval to be used (must be one of the following: "S", "M", "H", "D", "W0" - "W6", "midnight", refer to [this page](https://docs.python.org/3/library/logging.handlers.html#logging.handlers.TimedRotatingFileHandler) for more info) (default: "midnight")
@@ -26,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Log level for the "discord" logger is now controlled with `--discord-verbose`/`-dv`, `--discord-more-verbose`/`-dvv`, and `--discord-log-level`
   - Log level for the "fractalrhomb" logger is controlled with `--bot-verbose`/`-bv`, `--bot-more-verbose`/`-bvv`, and `--bot-log-level`
   - Log level for the root logger is now controlled with `--verbose`/`-v`, `--more-verbose`/`-vv`, and `--log-level`
+- Scripts should no longer modify the shell environment after being run (e.g. pwd should not change after running a script)
+- Bash scripts now use `python` instead of `python3`
+  - I'm not a Linux user, so this may or may not break things. But if you are a Linux user, you should be able to fix them
 
 ### Fixed
 - Notifications listener should no longer get stuck waiting to reconnect for absurd amounts of time
@@ -33,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Will now force it out of waiting when trying to reconnect
   - No longer reports that the listener was restarted when nothing happened
   - No longer leaves errant resume events when a restart isn't needed
+- Bash setup script checking for if `.env` _doesn't_ exist when trying to make a backup
 
 ## [0.8.0] - 2024-12-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing so far
+### Added
+- Some scripts for starting the bot (don't worry, you can still make your own)
+  - Any command line arguments given to the script will be passed to the bot
+- Customization for the file logger via .env
+  - `LOG_FILE_NAME` for the file name to be used (default: "discord.log")
+  - `LOG_FILE_WHEN` for the type of interval to be used (must be one of the following: "S", "M", "H", "D", "W0" - "W6", "midnight", refer to [this page](https://docs.python.org/3/library/logging.handlers.html#logging.handlers.TimedRotatingFileHandler) for more info) (default: "midnight")
+  - `LOG_FILE_INTERVAL` for the interval between roll over (default: 1)
+  - `LOG_FILE_BACKUP_COUNT` for how many old logs to keep (default: 7)
+  - `LOG_FILE_AT_TIME` for when to roll over if the interval type is a weekday or midnight, in ISO 8601 format (with Z for UTC time or no Z for local time) (default: 00:00:00Z)
+- Can enable outputting logs to console (stderr) with `--log-console`
+  - Log level outputted to console can be changed with `--console-log-level`
+- Can disable outputting logs to file with `--no-log-file`
+  - Log level outputted to file can be changed with `--file-log-level`
+
+### Changed
+- Logs for bot functions now use a "fractalrhomb" logger instead of the "discord" logger
+  - Log level for the "discord" logger is now controlled with `--discord-verbose`/`-dv`, `--discord-more-verbose`/`-dvv`, and `--discord-log-level`
+  - Log level for the "fractalrhomb" logger is controlled with `--bot-verbose`/`-bv`, `--bot-more-verbose`/`-bvv`, and `--bot-log-level`
+  - Log level for the root logger is now controlled with `--verbose`/`-v`, `--more-verbose`/`-vv`, and `--log-level`
 
 ## [0.8.0] - 2024-12-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Some scripts for starting the bot (don't worry, you can still make your own)
-  - Any command line arguments given to the script will be passed to the bot
+  - Any command line arguments given to the provided script will be passed to the bot
 - Customization for the file logger via .env
   - `LOG_FILE_NAME` for the file name to be used (default: "discord.log")
   - `LOG_FILE_WHEN` for the type of interval to be used (must be one of the following: "S", "M", "H", "D", "W0" - "W6", "midnight", refer to [this page](https://docs.python.org/3/library/logging.handlers.html#logging.handlers.TimedRotatingFileHandler) for more info) (default: "midnight")
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Log level for the "discord" logger is now controlled with `--discord-verbose`/`-dv`, `--discord-more-verbose`/`-dvv`, and `--discord-log-level`
   - Log level for the "fractalrhomb" logger is controlled with `--bot-verbose`/`-bv`, `--bot-more-verbose`/`-bvv`, and `--bot-log-level`
   - Log level for the root logger is now controlled with `--verbose`/`-v`, `--more-verbose`/`-vv`, and `--log-level`
+
+### Fixed
+- Notifications listener should no longer get stuck waiting to reconnect for absurd amounts of time
+- Several fixes regarding the restarting the notifications listener:
+  - Will now force it out of waiting when trying to reconnect
+  - No longer reports that the listener was restarted when nothing happened
+  - No longer leaves errant resume events when a restart isn't needed
 
 ## [0.8.0] - 2024-12-01
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,15 @@ A discord bot that uses the API of https://fractalthorns.com/
 
 ## Usage
 
-To use, it is recommended to activate the venv (from `.venv\scripts` or `.venv\bin`) and run the following command in the repository's root directory.
+To use, it is recommended to activate the venv (from `.venv\Scripts` on Windows or `.venv\bin` on Unix) and run the python script. For example:
 
 ```bat
+.venv\Scripts\activate.bat
 python fractalrhomb.py
+```
+```bash
+source .venv/bin/activate
+python3 fractalrhomb.py
 ```
 
 Make sure the `.env` file contains a valid bot token.

--- a/cogs/aetol.py
+++ b/cogs/aetol.py
@@ -163,7 +163,7 @@ class Aetol(discord.Cog):
 	def __init__(self, bot: discord.Bot) -> "Aetol":
 		"""Initialize the cog."""
 		self.bot: discord.Bot = bot
-		self.logger = logging.getLogger("discord.cogs.aetol")
+		self.logger = logging.getLogger("fractalrhomb.cogs.aetol")
 
 		self.particles: list[AetolParticle] = []
 		self.words: list[AetolWord] = []

--- a/cogs/fractalthorns.py
+++ b/cogs/fractalthorns.py
@@ -33,7 +33,7 @@ class Fractalthorns(discord.Cog):
 	def __init__(self, bot: discord.Bot) -> "Fractalthorns":
 		"""Initialize the cog."""
 		self.bot: discord.Bot = bot
-		self.logger = logging.getLogger("discord.cogs.fractalthorns")
+		self.logger = logging.getLogger("fractalrhomb.cogs.fractalthorns")
 
 	MAX_EPISODIC_LINE_ITEMS = 100
 

--- a/fractalrhomb.py
+++ b/fractalrhomb.py
@@ -33,19 +33,8 @@ from src.fractalthorns_exceptions import CachePurgeError
 load_dotenv()
 
 discord_logger = logging.getLogger("discord")
+fractalrhomb_logger = logging.getLogger("fractalrhomb")
 root_logger = logging.getLogger()
-
-log_handler = logging.handlers.TimedRotatingFileHandler(
-	filename="discord.log", when="midnight", backupCount=7, encoding="utf-8", utc=True
-)
-dt_fmt = "%Y-%m-%d %H:%M:%S"
-log_formatter = logging.Formatter(
-	"[{asctime}] [{levelname:<8}] {name}: {message}", dt_fmt, style="{"
-)
-log_handler.setFormatter(log_formatter)
-root_logger.addHandler(log_handler)
-
-PING_LATENCY_HIGH = 10.0
 
 
 @bot.event
@@ -68,7 +57,7 @@ async def private_commands(message: discord.Message) -> None:
 
 	if message.content.startswith("-say"):
 		if user_id not in allowed:
-			discord_logger.info(
+			fractalrhomb_logger.info(
 				"User %s tried to use -say, but is not part of %s", user_id, allowed
 			)
 			return
@@ -77,7 +66,7 @@ async def private_commands(message: discord.Message) -> None:
 
 	if message.content.startswith("-status"):
 		if user_id not in allowed:
-			discord_logger.info(
+			fractalrhomb_logger.info(
 				"User %s tried to use -status, but is not part of %s", user_id, allowed
 			)
 			return
@@ -86,7 +75,7 @@ async def private_commands(message: discord.Message) -> None:
 
 	if message.content.startswith("-botdata"):
 		if user_id not in allowed:
-			discord_logger.info(
+			fractalrhomb_logger.info(
 				"User %s tried to use -botdata, but is not part of %s", user_id, allowed
 			)
 			return
@@ -98,26 +87,26 @@ async def say_message_command(message: discord.Message) -> None:
 	"""Send a message in a specified channel."""
 	args = message.content.split(" ", 2)
 
-	discord_logger.debug(
+	fractalrhomb_logger.debug(
 		"Received -say command: %s. Parsed as: %s.", message.content, args
 	)
 
 	if len(args) < 3:  # noqa: PLR2004
-		discord_logger.debug("Command did not receive enough arguments.")
+		fractalrhomb_logger.debug("Command did not receive enough arguments.")
 		return
 
 	channel = args[1]
 	content = args[2]
 
-	discord_logger.debug("Parsed channel as %s and content as %s.", channel, content)
+	fractalrhomb_logger.debug("Parsed channel as %s and content as %s.", channel, content)
 
 	try:
 		discord_channel = bot.get_channel(int(channel))
 		if discord_channel is None:
-			discord_logger.debug("%s is not a valid channel.", channel)
+			fractalrhomb_logger.debug("%s is not a valid channel.", channel)
 			return
 	except ValueError:
-		discord_logger.debug("%s is not a channel id.", channel)
+		fractalrhomb_logger.debug("%s is not a channel id.", channel)
 		return
 
 	await discord_channel.send(content)
@@ -127,12 +116,12 @@ async def change_status_command(message: discord.Message) -> None:
 	"""Change the bot's status."""
 	args = message.content.split(" ", 1)
 
-	discord_logger.debug(
+	fractalrhomb_logger.debug(
 		"Received -status command: %s. Parsed as: %s.", message.content, args
 	)
 
 	if len(args) < 2:  # noqa: PLR2004
-		discord_logger.debug("Did not receive enough arguments.")
+		fractalrhomb_logger.debug("Did not receive enough arguments.")
 		return
 
 	content = args[1]
@@ -154,17 +143,17 @@ async def bot_data_command(message: discord.Message) -> None:
 	"""Save or reload bot data."""
 	args = message.content.split(" ", 2)
 
-	discord_logger.debug(
+	fractalrhomb_logger.debug(
 		"Received -botdata command: %s. Parsed as: %s.", message.content, args
 	)
 
 	if len(args) < 2:  # noqa: PLR2004
-		discord_logger.debug("Command did not receive enough arguments.")
+		fractalrhomb_logger.debug("Command did not receive enough arguments.")
 		return
 
 	action = args[1]
 
-	discord_logger.debug("Parsed action as %s.", action)
+	fractalrhomb_logger.debug("Parsed action as %s.", action)
 
 	match action:
 		case "save":
@@ -174,7 +163,7 @@ async def bot_data_command(message: discord.Message) -> None:
 		case "reload":
 			await frg.bot_data.load(frg.BOT_DATA_PATH)
 		case _:
-			discord_logger.debug("Action is not valid.")
+			fractalrhomb_logger.debug("Action is not valid.")
 
 
 @bot.event
@@ -190,7 +179,7 @@ async def on_application_command_error(
 @bot.slash_command(description="Pong!")
 async def ping(ctx: discord.ApplicationContext) -> None:
 	"""Pong."""
-	frg.discord_logger.info(
+	fractalrhomb_logger.info(
 		"Ping command used. Latency: %s ms", round(bot.latency * 1000)
 	)
 
@@ -201,7 +190,7 @@ async def ping(ctx: discord.ApplicationContext) -> None:
 @bot.slash_command(name="license")
 async def show_license(ctx: discord.ApplicationContext) -> None:
 	"""Display the bot's license message."""
-	frg.discord_logger.info("License command used")
+	fractalrhomb_logger.info("License command used")
 
 	license_text = (
 		">>> fractalrhomb\n"
@@ -242,7 +231,7 @@ async def purge(
 	ctx: discord.ApplicationContext, cache: str, *, force: bool = False
 ) -> None:
 	"""Purge the bot's cache."""
-	frg.discord_logger.info("Purge command used (cache=%s, force=%s)", cache, force)
+	fractalrhomb_logger.info("Purge command used (cache=%s, force=%s)", cache, force)
 
 	user = str(ctx.author.id)
 
@@ -250,7 +239,7 @@ async def purge(
 		force_purge_allowed = json.loads(getenv("BOT_ADMIN_USERS"))
 
 		if user not in force_purge_allowed:
-			discord_logger.warning("Unauthorized force purge attempt by %s.", user)
+			fractalrhomb_logger.warning("Unauthorized force purge attempt by %s.", user)
 
 			response = "you cannot do that."
 			await frg.send_message(ctx, response)
@@ -265,7 +254,7 @@ async def purge(
 	if force:
 		fractalthorns_api.purge_cache(cache, force_purge=True)
 
-		discord_logger.info('"%s" force purged by %s.', cache.value, ctx.author.id)
+		fractalrhomb_logger.info('"%s" force purged by %s.', cache.value, ctx.author.id)
 
 		response = f"successfully force purged {cache.value}"
 		await frg.send_message(ctx, response)
@@ -307,7 +296,7 @@ async def purge(
 		try:
 			await frg.bot_data.save(frg.BOT_DATA_PATH)
 		except Exception:
-			discord_logger.exception("Could not save bot data.")
+			fractalrhomb_logger.exception("Could not save bot data.")
 
 
 async def purge_all(ctx: discord.ApplicationContext, *, force: bool) -> None:
@@ -325,7 +314,7 @@ async def purge_all(ctx: discord.ApplicationContext, *, force: bool) -> None:
 
 			fractalthorns_api.purge_cache(cache, force_purge=True)
 
-		discord_logger.info("All caches force purged by %s.", user)
+		fractalrhomb_logger.info("All caches force purged by %s.", user)
 
 		response = "successfully force purged all caches"
 		await frg.send_message(ctx, response)
@@ -371,12 +360,12 @@ async def purge_all(ctx: discord.ApplicationContext, *, force: bool) -> None:
 		response = f"successfully purged {", ".join(purged)}"
 		await frg.send_message(ctx, response)
 
-		discord_logger.info("%s purged by %s.", ('", "'.join(purged)), ctx.author.id)
+		fractalrhomb_logger.info("%s purged by %s.", ('", "'.join(purged)), ctx.author.id)
 
 		try:
 			await frg.bot_data.save(frg.BOT_DATA_PATH)
 		except Exception:
-			discord_logger.exception("Could not save bot data.")
+			fractalrhomb_logger.exception("Could not save bot data.")
 	else:
 		earliest = min(cooldown, key=cooldown.get)
 
@@ -415,7 +404,7 @@ async def add_bot_channel(
 	hidden: bool = False,
 ) -> None:
 	"""Mark a channel as a special type (requires Manage Server permission)."""
-	frg.discord_logger.info(
+	fractalrhomb_logger.info(
 		"Add special channel command used (type_=%s, channel=%s, hidden=%s)",
 		type_,
 		channel,
@@ -481,7 +470,7 @@ async def remove_bot_channel(
 	hidden: bool = False,
 ) -> None:
 	"""Unmark a channel as a special type (requires Manage Server permission)."""
-	frg.discord_logger.info(
+	fractalrhomb_logger.info(
 		"Remove special channel command used (type_=%s, channel=%s, hidden=%s)",
 		type_,
 		channel,
@@ -538,7 +527,7 @@ async def remove_all_bot_channels(
 	ctx: discord.ApplicationContext, type_: str, *, hidden: bool = False
 ) -> None:
 	"""Unmark all channels as a special type (requires Manage Server permission)."""
-	frg.discord_logger.info(
+	fractalrhomb_logger.info(
 		"Remove all bot channels command used (type_=%s, hidden=%s)", type_, hidden
 	)
 
@@ -573,7 +562,7 @@ async def remove_all_bot_channels(
 @bot.slash_command(name="test")
 async def test_command(ctx: discord.ApplicationContext) -> None:
 	"""Test command."""
-	frg.discord_logger.info("Test command used")
+	fractalrhomb_logger.info("Test command used")
 	await ctx.respond(getenv("LOOK2_EMOJI", ":look2:"))
 
 
@@ -584,7 +573,7 @@ async def restart_notification_listener(ctx: discord.ApplicationContext) -> None
 
 	user_id = str(ctx.author.id)
 	if user_id not in privileged_users:
-		discord_logger.warning(
+		fractalrhomb_logger.warning(
 			"Unauthorized notif listener restart attempt by %s.", user_id
 		)
 		response = "you cannot do that."
@@ -611,65 +600,151 @@ def parse_arguments() -> None:
 		"-v",
 		"--verbose",
 		action="store_true",
-		help="verbose logging for the bot (info)",
+		help="verbose logging for everything (info)",
 	)
 	parser.add_argument(
 		"-vv",
 		"--more-verbose",
 		action="store_true",
-		help="even more verbose logging for the bot (debug). overrides --verbose",
-	)
-	parser.add_argument(
-		"-rv",
-		"--root-verbose",
-		action="store_true",
-		help="verbose logging for everything (info)",
-	)
-	parser.add_argument(
-		"-rvv",
-		"--root-more-verbose",
-		action="store_true",
 		help="even more verbose logging for everything (debug). overrides --root-verbose",
+	)
+	parser.add_argument(
+		"-dv",
+		"--discord-verbose",
+		action="store_true",
+		help="verbose logging for discord operations (info)",
+	)
+	parser.add_argument(
+		"-dvv",
+		"--discord-more-verbose",
+		action="store_true",
+		help="even more verbose logging for discord operations (debug). overrides --discord-verbose",
+	)
+	parser.add_argument(
+		"-bv",
+		"--bot-verbose",
+		action="store_true",
+		help="verbose logging for the bot (info)",
+	)
+	parser.add_argument(
+		"-bvv",
+		"--bot-more-verbose",
+		action="store_true",
+		help="even more verbose logging for the bot (debug). overrides --bot-verbose",
 	)
 	parser.add_argument(
 		"--log-level",
 		choices=["none", "critical", "error", "warning", "info", "debug", "notset"],
-		help="set a log level for the bot. overrides --verbose and --more-verbose. if not set, uses root log level",
+		help="set a log level for everything (root). overrides --verbose and --more-verbose. default: warning",
 		default=None,
 	)
 	parser.add_argument(
-		"--root-log-level",
+		"--discord-log-level",
 		choices=["none", "critical", "error", "warning", "info", "debug", "notset"],
-		help="set a log level for everything. overrides --root-verbose and --root-more-verbose. default: warning",
+		help="set a log level for discord operations. overrides --discord-verbose and --discord-more-verbose. if not set, uses root log level.",
 		default=None,
+	)
+	parser.add_argument(
+		"--bot-log-level",
+		choices=["none", "critical", "error", "warning", "info", "debug", "notset"],
+		help="set a log level for the bot. overrides --bot-verbose and --bot-more-verbose. if not set, uses root log level.",
+		default=None,
+	)
+	parser.add_argument(
+		"--log-console",
+		dest="log_to_console",
+		action="store_true",
+		help="output logs to console (stderr)",
+	)
+	parser.add_argument(
+		"--console-log-level",
+		choices=["critical", "error", "warning", "info", "debug", "notset"],
+		help="set a log level for logging messages to console. does nothing if used without --log-console. if not set, logs everything.",
+		default="notset",
+	)
+	parser.add_argument(
+		"--no-log-file",
+		dest="log_to_file",
+		action="store_false",
+		help="don't output logs to a file",
+	)
+	parser.add_argument(
+		"--file-log-level",
+		choices=["critical", "error", "warning", "info", "debug", "notset"],
+		help="set a log level for logging messages to file. does nothing if used with --no-log-file. if not set, logs everything.",
+		default="notset",
 	)
 	args = parser.parse_args()
 
 	if args.verbose:
-		discord_logger.setLevel(logging.INFO)
-	if args.root_verbose:
 		root_logger.setLevel(logging.INFO)
+	if args.discord_verbose:
+		discord_logger.setLevel(logging.INFO)
+	if args.bot_verbose:
+		fractalrhomb_logger.setLevel(logging.INFO)
 
 	if args.more_verbose:
-		discord_logger.setLevel(logging.DEBUG)
-	if args.root_more_verbose:
 		root_logger.setLevel(logging.DEBUG)
+	if args.discord_more_verbose:
+		discord_logger.setLevel(logging.DEBUG)
+	if args.bot_more_verbose:
+		fractalrhomb_logger.setLevel(logging.DEBUG)
 
 	if args.log_level is not None:
 		args.log_level = args.log_level.upper()
 
 		if args.log_level == "NONE":
-			discord_logger.setLevel(logging.CRITICAL + 10)
-		else:
-			discord_logger.setLevel(args.log_level)
-
-	if args.root_log_level is not None:
-		args.root_log_level = args.root_log_level.upper()
-
-		if args.root_log_level == "NONE":
 			root_logger.setLevel(logging.CRITICAL + 10)
 		else:
-			root_logger.setLevel(args.root_log_level)
+			root_logger.setLevel(args.log_level)
+
+	if args.discord_log_level is not None:
+		args.discord_log_level = args.discord_log_level.upper()
+
+		if args.discord_log_level == "NONE":
+			discord_logger.setLevel(logging.CRITICAL + 10)
+		else:
+			discord_logger.setLevel(args.discord_log_level)
+
+	if args.bot_log_level is not None:
+		args.bot_log_level = args.bot_log_level.upper()
+
+		if args.bot_log_level == "NONE":
+			fractalrhomb_logger.setLevel(logging.CRITICAL + 10)
+		else:
+			fractalrhomb_logger.setLevel(args.bot_log_level)
+
+	dt_fmt = "%Y-%m-%d %H:%M:%S"
+	log_formatter = logging.Formatter(
+		"[{asctime}] [{levelname:<8}] {name}: {message}", dt_fmt, style="{"
+	)
+
+	if args.log_to_file:
+		log_file_name = getenv("LOG_FILE_NAME", "discord.log")
+		log_file_when = getenv("LOG_FILE_WHEN", "midnight")
+		log_file_interval = getenv("LOG_FILE_INTERVAL", "1")
+		log_file_backup_count = getenv("LOG_FILE_BACKUP_COUNT", "7")
+		log_file_at_time = getenv("LOG_FILE_AT_TIME", "00:00:00Z")
+
+		log_file_interval = int(log_file_interval)
+		log_file_backup_count = int(log_file_backup_count)
+		log_file_utc = "Z" in log_file_at_time
+		log_file_at_time = dt.time.fromisoformat(log_file_at_time)
+
+		log_file_handler = logging.handlers.TimedRotatingFileHandler(
+			filename=log_file_name, when=log_file_when, interval=log_file_interval, backupCount=log_file_backup_count, encoding="utf-8", utc=log_file_utc, atTime=log_file_at_time
+		)
+		log_file_handler.setFormatter(log_formatter)
+
+		log_file_handler.setLevel(args.file_log_level.upper())
+
+		root_logger.addHandler(log_file_handler)
+
+	if args.log_to_console:
+		log_stream_handler = logging.StreamHandler()
+		log_stream_handler.setFormatter(log_formatter)
+		log_stream_handler.setLevel(args.console_log_level.upper())
+		root_logger.addHandler(log_stream_handler)
 
 
 async def main() -> None:
@@ -679,7 +754,7 @@ async def main() -> None:
 	try:
 		await frg.bot_data.load(frg.BOT_DATA_PATH)
 	except Exception:
-		discord_logger.exception("Could not load bot data.")
+		fractalrhomb_logger.exception("Could not load bot data.")
 
 	activity_text = frg.bot_data.status
 	if activity_text is not None:

--- a/setup.bat
+++ b/setup.bat
@@ -1,4 +1,7 @@
 @echo off
+SETLOCAL
+
+cd /d %~dp0
 
 echo Creating venv
 python -m venv .venv
@@ -16,5 +19,8 @@ echo FRACTALTHORNS_USER_AGENT="Fractal-RHOMB/{VERSION_SHORT}" > .env
 echo DISCORD_BOT_TOKEN="Replace me!" >> .env
 echo BOT_ADMIN_USERS=[] >> .env
 
+deactivate
+
 echo Setup complete
+echo Add a bot token to .env and use start_bot.bat to run
 pause

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,31 @@
+Push-Location $PSScriptRoot
+
+Write-Host "Creating venv"
+python -m venv .venv
+
+Write-Host "Activating venv"
+& ".venv\Scripts\Activate.ps1"
+
+Write-Host "Installing requirements"
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+
+Write-Host "Creating .env"
+if (Test-Path ".env") {
+	if (Test-Path ".env.bak") {
+		Move-Item -Confirm -Force ".env" ".env.bak"
+	}
+	else {
+		Move-Item ".env" ".env.bak"
+	}
+}
+
+Write-Output 'FRACTALTHORNS_USER_AGENT="Fractal-RHOMB/{VERSION_SHORT}"' > ".env"
+Write-Output 'DISCORD_BOT_TOKEN="Replace me!"' >> ".env"
+Write-Output 'BOT_ADMIN_USERS=[]' >> ".env"
+
+deactivate
+Pop-Location
+
+Write-Host "Setup complete"
+Write-Host "Add a bot token to .env and use start_bot.ps1 to run"

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,7 @@ echo Activating venv
 source .venv/bin/activate
 
 echo Installing requirements
-python -m pip install --upgrade pip
+python3 -m pip install --upgrade pip
 pip install -r requirements.txt
 
 echo Creating .env

--- a/setup.sh
+++ b/setup.sh
@@ -1,23 +1,33 @@
 #!/bin/bash
 
+cd ${0%/*}
+
 echo Creating venv
-python3 -m venv .venv
+python -m venv .venv
 
 echo Activating venv
-source .venv/bin/activate
+
+if [ -f .venv/Scripts/activate ]; then
+	source .venv/Scripts/activate
+else
+	source .venv/bin/activate
+fi
 
 echo Installing requirements
-python3 -m pip install --upgrade pip
+python -m pip install --upgrade pip
 pip install -r requirements.txt
 
 echo Creating .env
-if [ ! -f ./.env ]; then
+if [ -f ./.env ]; then
 	mv -ib .env .env.bak
 fi
-echo FRACTALTHORNS_USER_AGENT="Fractal-RHOMB/{VERSION_SHORT}" > .env
-echo DISCORD_BOT_TOKEN="Replace me!" >> .env
-echo BOT_ADMIN_USERS=[] >> .env
+echo 'FRACTALTHORNS_USER_AGENT="Fractal-RHOMB/{VERSION_SHORT}"' > .env
+echo 'DISCORD_BOT_TOKEN="Replace me!"' >> .env
+echo 'BOT_ADMIN_USERS=[]' >> .env
+
+deactivate
 
 echo Setup complete
+echo Add a bot token to .env and use start_bot.sh to run
 read -n1 -r -s -p "Press any key to continue..."
 echo

--- a/src/fractalrhomb_globals.py
+++ b/src/fractalrhomb_globals.py
@@ -74,7 +74,7 @@ def regex_incorrectly_formatted(regex: str = "regex", is_or_are: str = "is") -> 
 	return f"the {regex} {is_or_are} not formatted correctly. please try again"
 
 
-discord_logger = logging.getLogger("discord")
+fractalrhomb_logger = logging.getLogger("fractalrhomb")
 session: aiohttp.ClientSession = None
 
 
@@ -90,41 +90,41 @@ class BotData:
 
 	async def load(self, fp: str) -> None:
 		"""Load data from file."""
-		discord_logger.info("Loading bot data.")
+		fractalrhomb_logger.info("Loading bot data.")
 
 		if not Path(fp).exists():
-			discord_logger.info("Did not find saved bot data.")
+			fractalrhomb_logger.info("Did not find saved bot data.")
 			return
 
 		async with aiofiles.open(fp) as f:
 			data = json.loads(await f.read())
 			if data.get("bot_channels") is not None:
-				discord_logger.info("Loaded saved bot channels.")
+				fractalrhomb_logger.info("Loaded saved bot channels.")
 				self.bot_channels = data["bot_channels"]
 			if data.get("news_post_channels") is not None:
-				discord_logger.info("Loaded saved news post channels.")
+				fractalrhomb_logger.info("Loaded saved news post channels.")
 				self.news_post_channels = data["news_post_channels"]
 			if data.get("purge_cooldowns") is not None:
-				discord_logger.info("Loaded saved purge cooldowns.")
+				fractalrhomb_logger.info("Loaded saved purge cooldowns.")
 				self.purge_cooldowns = data["purge_cooldowns"]
 			if data.get("gather_cooldowns") is not None:
-				discord_logger.info("Loaded saved gather cooldowns.")
+				fractalrhomb_logger.info("Loaded saved gather cooldowns.")
 				self.gather_cooldowns = data["gather_cooldowns"]
 			if data.get("status") is not None:
-				discord_logger.info("Loaded saved status.")
+				fractalrhomb_logger.info("Loaded saved status.")
 				self.status = data["status"]
 
 	async def save(self, fp: str) -> None:
 		"""Save data to file."""
-		discord_logger.info("Saving bot data.")
+		fractalrhomb_logger.info("Saving bot data.")
 
 		if Path(fp).exists():
 			backup = f"{fp}.bak"
 			await aiofiles.os.replace(fp, backup)
-			discord_logger.info("Backed up old bot data file.")
+			fractalrhomb_logger.info("Backed up old bot data file.")
 		async with aiofiles.open(fp, "w") as f:
 			await f.write(json.dumps(asdict(self), indent=4))
-			discord_logger.info("Saved bot data.")
+			fractalrhomb_logger.info("Saved bot data.")
 
 
 bot_data = BotData({}, [], {}, {}, None)
@@ -429,7 +429,7 @@ async def send_message(
 				await ctx.respond(f"{user}{message}")
 		except discord.errors.HTTPException as exc:
 			if exc.code == INTERACTION_TOO_MANY_FOLLOW_UP_MESSAGES_ERROR_CODE:
-				discord_logger.debug(
+				fractalrhomb_logger.debug(
 					"Too many follow up messages have been sent. Truncating."
 				)
 				return False

--- a/src/fractalrhomb_globals.py
+++ b/src/fractalrhomb_globals.py
@@ -53,11 +53,11 @@ NO_ITEMS_MATCH_SEARCH = "no items match the requested parameters"
 INTERACTION_TOO_MANY_FOLLOW_UP_MESSAGES_ERROR_CODE = 40094
 
 # The full version number including anything extra.
-FRACTALRHOMB_VERSION_FULL = "0.8.0"
+FRACTALRHOMB_VERSION_FULL = "0.9.0-pre.start-up"
 # Version number with only Major, Minor, and Patch version.
-FRACTALRHOMB_VERSION_LONG = "0.8.0"
+FRACTALRHOMB_VERSION_LONG = "0.9.0"
 # Verison number with only Major and Minor version.
-FRACTALRHOMB_VERSION_SHORT = "0.8"
+FRACTALRHOMB_VERSION_SHORT = "0.9"
 
 FRACTALTHORNS_USER_AGENT = os.getenv(
 	"FRACTALTHORNS_USER_AGENT", "Fractal-RHOMB/{VERSION_SHORT}"

--- a/start_bot.bat
+++ b/start_bot.bat
@@ -1,0 +1,8 @@
+@echo off
+
+cd /d %~dp0
+call .venv\Scripts\activate.bat
+
+echo Starting bot
+
+python fractalrhomb.py %*

--- a/start_bot.bat
+++ b/start_bot.bat
@@ -1,4 +1,5 @@
 @echo off
+SETLOCAL
 
 cd /d %~dp0
 call .venv\Scripts\activate.bat
@@ -6,3 +7,5 @@ call .venv\Scripts\activate.bat
 echo Starting bot
 
 python fractalrhomb.py %*
+
+deactivate

--- a/start_bot.ps1
+++ b/start_bot.ps1
@@ -1,0 +1,12 @@
+Push-Location $PSScriptRoot
+& ".venv\Scripts\Activate.ps1"
+
+Write-Host "Starting bot"
+
+try {
+	python "fractalrhomb.py" @args
+}
+finally {
+	deactivate
+	Pop-Location
+}

--- a/start_bot.sh
+++ b/start_bot.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cd ${0%/*}
+source .venv/bin/activate
+
+echo "Starting bot"
+
+python3 fractalrhomb.py $*

--- a/start_bot.sh
+++ b/start_bot.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
 cd ${0%/*}
-source .venv/bin/activate
+
+if [ -f .venv/Scripts/activate ]; then
+	source .venv/Scripts/activate
+else
+	source .venv/bin/activate
+fi
 
 echo "Starting bot"
 
-python3 fractalrhomb.py $*
+python fractalrhomb.py $*


### PR DESCRIPTION
It was bothering me that the only way to customize parts of the logger (like when or how often to roll over log files) was only possible by modifying the code, so this changes that. The discord _library_ logger and the discord _bot_ logger are now also separate, and you can enable/disable outputting logs to console/file.